### PR TITLE
GraphQL Backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
+    "bulk-mail-cli": "^2.0.6",
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",
     "dotenv": "^8.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.3",
+    "@types/node-cron": "^2.0.2",
+    "@types/nodemailer": "^6.4.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "babel-eslint": "^9.0.0",
@@ -42,6 +44,7 @@
     "graphql-yoga": "^1.18.3",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.7.7",
+    "node-cron": "^2.0.3",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -34,6 +34,7 @@ server.use(
 server.start(
   {
     endpoint: '/api/graphql',
+    cacheControl: false,
   },
   details => console.log(`GraphQL Server is running on PORT ${details.port}`)
 )

--- a/packages/backend/src/resolvers/index.ts
+++ b/packages/backend/src/resolvers/index.ts
@@ -1,4 +1,6 @@
 import exampleMutation from './mutations/exampleMutation'
+import sendMails from './mutations/sendMails'
+
 import exampleQuery from './queries/exampleQuery'
 
 export default {
@@ -7,5 +9,6 @@ export default {
   },
   Mutation: {
     exampleMutation,
+    sendMails,
   },
 }

--- a/packages/backend/src/resolvers/mutations/sendMails.ts
+++ b/packages/backend/src/resolvers/mutations/sendMails.ts
@@ -1,14 +1,187 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-plusplus */
 
-import { stringProcessor } from 'bulk-mail-cli'
+import * as cron from 'node-cron'
+import {
+  stringProcessor,
+  createTransport,
+  isForLoop,
+  BmcConfigurationFile,
+} from 'bulk-mail-cli'
 
-const sendMails = (parent, args, context, info): string => {
-  const massMail = stringProcessor('{{email|fname|jnume}}', {
-    email: 'kumar@iqubex.com',
-    fname: 'Kumar',
-  })
+import Mail from 'nodemailer/lib/mailer'
 
-  return massMail
+const sendMails = async (
+  parent,
+  {
+    configuration,
+    shouldRestart = false,
+  }: { configuration: BmcConfigurationFile; shouldRestart: boolean }
+): Promise<object> => {
+  // Create a NodeMailer transporter
+  const transporter: Mail = createTransport(configuration)
+
+  // Define the variables
+  const {
+    mail: { to, theme },
+  } = configuration
+
+  let csvData
+  let htmlData
+
+  try {
+    csvData = JSON.parse(to)
+    htmlData = theme
+  } catch (error) {
+    throw new Error('Data not provided in the preferred format')
+  }
+
+  // Function that will run after the task is done.
+  const logResult = (error?: Error): void => {
+    // if (isError) {
+    if (error) {
+      throw new Error(error?.message)
+    } else {
+      throw new Error('Some problem occured.')
+    }
+  }
+
+  // Gather important information
+  let sentTo = configuration?.nonUserData?.sentTo
+
+  let csvDataWithoutSentTo
+
+  if (shouldRestart) {
+    csvDataWithoutSentTo = csvData
+  } else {
+    csvDataWithoutSentTo = csvData.filter(row => {
+      if (sentTo) return !sentTo.includes(row.email)
+      return true
+    })
+  }
+
+  const mailIntervalDuration: string =
+    configuration?.configuration?.mailInterval || '*/10 * * * * *'
+
+  let dataIndex = 0
+
+  async function sendMail(
+    row,
+    task: cron.ScheduledTask | 'forloop'
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    // String Processor
+    const processString = (string): string =>
+      stringProcessor(string, { ...row, ...process.env }) // TODO: Find a way to process env variables
+
+    try {
+      await transporter.sendMail({
+        from: processString(configuration?.mail?.from),
+        subject: processString(configuration?.mail?.subject),
+        html: processString(htmlData),
+        to: processString(row?.email),
+
+        // Use string processors on the filename of the attachment.
+        attachments: configuration.mail.attachments
+          ? configuration?.mail?.attachments.map(attachment => ({
+              ...attachment,
+              filename: processString(attachment.filename),
+              path: attachment?.path.startsWith('http')
+                ? processString(attachment.path)
+                : null, // TODO: 'path' management
+            }))
+          : [],
+      })
+
+      if (!sentTo) sentTo = []
+
+      sentTo.push(row?.email)
+
+      // TODO: Write back everytime a mail is sent.
+      // await fs.writeFileSync(
+      //   configuration.jsonConfPath,
+      //   JSON.stringify(
+      //     {
+      //       ...configurationToWriteFile,
+      //       nonUserData: {
+      //         sentTo,
+      //       },
+      //     },
+      //     null,
+      //     2
+      //   )
+      // )
+
+      // GraphQL way to log messages live? Maybe GraphQL subscriptions?
+      // configuration?.configuration?.verbose !== false &&
+      //   console.log(`${chalk.yellow(`Mail sent to ${row.email}.`)}`)
+    } catch (error) {
+      logResult(error)
+
+      if (typeof task === 'object') task.destroy()
+      else return 'break'
+    }
+
+    if (dataIndex > csvDataWithoutSentTo.length) {
+      logResult()
+
+      if (typeof task === 'object') task.destroy()
+      else return 'break'
+    }
+
+    dataIndex++
+  }
+
+  if (csvDataWithoutSentTo.length > 0) {
+    if (isForLoop(mailIntervalDuration)) {
+      // Do in For-Loop
+      for (const row of csvDataWithoutSentTo) {
+        let sendingProcess
+
+        if (row) {
+          sendingProcess = await sendMail(row, 'forloop')
+        }
+
+        if (
+          typeof sendingProcess === 'function' &&
+          sendingProcess() === 'break'
+        ) {
+          break
+        }
+      }
+    } else {
+      // Do in Cron
+      const task: cron.ScheduledTask = cron.schedule(
+        mailIntervalDuration,
+        async () => {
+          const row = csvDataWithoutSentTo[dataIndex]
+
+          if (row) {
+            await sendMail(row, task)
+          }
+        }
+      )
+
+      task.start()
+    }
+  } else {
+    if (csvData.length > 0 && sentTo.length > 0) {
+      logResult(
+        new Error(
+          'Email campaign is already complete. Please check your updated configuration file'
+        )
+      )
+    } else {
+      logResult(new Error('The provided CSV file is probably empty'))
+    }
+
+    logResult(new Error('csvDataWithoutSentTo is empty'))
+  }
+
+  return {
+    message: 'Emails sent.',
+  }
 }
 
 export default sendMails

--- a/packages/backend/src/resolvers/mutations/sendMails.ts
+++ b/packages/backend/src/resolvers/mutations/sendMails.ts
@@ -1,0 +1,14 @@
+/* eslint-disable no-plusplus */
+
+import { stringProcessor } from 'bulk-mail-cli'
+
+const sendMails = (parent, args, context, info): string => {
+  const massMail = stringProcessor('{{email|fname|jnume}}', {
+    email: 'kumar@iqubex.com',
+    fname: 'Kumar',
+  })
+
+  return massMail
+}
+
+export default sendMails

--- a/packages/backend/src/resolvers/queries/exampleQuery.ts
+++ b/packages/backend/src/resolvers/queries/exampleQuery.ts
@@ -1,4 +1,3 @@
-const exampleQuery = (parent, args, context, info): string =>
-  'This is an example query.'
+const exampleQuery = (): string => 'This is an example query.'
 
 export default exampleQuery

--- a/packages/backend/src/utils/schema.ts
+++ b/packages/backend/src/utils/schema.ts
@@ -1,6 +1,7 @@
 const typeDefs = `
   type Mutation {
     exampleMutation: String
+    sendMails: String
   }
 
   type Query {

--- a/packages/backend/src/utils/schema.ts
+++ b/packages/backend/src/utils/schema.ts
@@ -1,9 +1,58 @@
 const typeDefs = `
-  type Mutation {
-    exampleMutation: String
-    sendMails: String
+  # Bmc Configuration Settings
+  input BmcCredential {
+    email: String!
+    password: String!
+    host: String!
+    port: Int!
+    secureConnection: Boolean!
+    proxy: String
   }
 
+  input BmcAttachment {
+    filename: String!
+    path: String!
+  }
+
+  input BmcMailSettings {
+    subject: String!
+    from: String!
+    to: String! # This should be stringified version of json object that contains the CsvData.
+    theme: String! # This should be stringified version of an HTML document.
+    attachments: [BmcAttachment]
+  }
+
+  input BmcConfigurations {
+    mailInterval: String
+    verbose: Boolean
+  }
+
+  input BmcNonUserData {
+    sentTo: [String]!
+  }
+
+  input BmcMasterConfiguration {
+    credentials: BmcCredential!
+    mail: BmcMailSettings!
+    configuration: BmcConfigurations
+    nonUserData: BmcNonUserData
+  }
+
+  # Returned data after Mails Sent
+  type MailSentResponse {
+    message: String!
+  }
+
+  # Mutations
+  type Mutation {
+    exampleMutation: String
+    sendMails(
+      configuration: BmcMasterConfiguration
+      shouldRestart: Boolean = false
+    ): MailSentResponse!
+  }
+
+  # Queries
   type Query {
     exampleQuery: String
   }


### PR DESCRIPTION
The GraphQL Backend has a `sendMails` mutation.

Check out the GraphQL documentation of the mutation at `https://localhost:4000` and try using it in the playground.

Example Query ✨
```graphql
mutation {
  sendMails(
    configuration: {
      credentials: {
        email: "email"
        password: "password"
        host: "smtp.gmail.com"
        port: 465
        secureConnection: true
      }
      mail: {
        subject: "Hi, this is a test mail!"
        from: "Kumar Abhirup <myemail@gmail.com>"
        to: "[{\"email\": \"kumar@gmail.co\", \"name\": \"Kumar\"}, {\"email\": \"abhirup@gmail.in\", \"name\": \"Abhirup\"}]",
        theme: "<h1>{{Hi|Howdy}}, {{fname}}!</h1>",
        attachments: [{
          path: "https://github.com/KumarAbhirup/resume/raw/master/Kumar%20Abhirup%20CV.pdf"
          filename: "resume.pdf"
        }]
      }
      configuration: { mailInterval: "* * * * * *" }
    }
    shouldRestart: false
  ) {
    message
  }
}
```

Try playing with it and let me know your thoughts.